### PR TITLE
Add Rayfin BaaS platform to Fabric tools

### DIFF
--- a/DataAISolutionArea-Fabric.md
+++ b/DataAISolutionArea-Fabric.md
@@ -62,6 +62,7 @@ Source | Description | Notes
 :----- | :-----  | :-----
 [Microsoft Fabric CLI](https://github.com/microsoft/fabric-cli) | The Microsoft Fabric CLI (fab) is a powerful, file-system-inspired command-line interface for Microsoft Fabric. Explore, automate, and script your Fabric environment directly from your terminal with familiar commands like ls, cd, mkdir, cp, and more.| GitHub
 [Fabric Toolbox](https://github.com/microsoft/fabric-toolbox/tree/main) | Fabric toolbox is a repository of tools, accelerators, scripts, and samples to help you work with Microsoft Fabric. This repository is brought to you by the Fabric Customer Advisory Team (CAT) and will continue to grow as we develop new tools and accelerators.| GitHub
+[Rayfin](https://github.com/microsoft/rayfin) | A fully managed Backend-as-a-Service (BaaS) platform built on Microsoft Fabric for the agentic era. Define your data model with TypeScript decorators and Rayfin provisions and manages database, authentication, data APIs, storage, and hosting. | GitHub
 
 
 ## Access Fabric


### PR DESCRIPTION
Added [Microsoft Rayfin](https://github.com/microsoft/rayfin) to the **Tools** section of \DataAISolutionArea-Fabric.md\.

Rayfin is a fully managed Backend-as-a-Service (BaaS) platform built on Microsoft Fabric for the agentic era — define data models with TypeScript decorators and get database, auth, APIs, storage, and hosting managed automatically.

Closes #273